### PR TITLE
[feature] keycloak develop

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.cloud:spring-cloud-starter-gateway-server-webflux'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.boot:spring-boot-starter-oauth2-resource-server'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.projectreactor:reactor-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/trustamarket/apigateway/config/SecurityConfig.java
+++ b/src/main/java/com/trustamarket/apigateway/config/SecurityConfig.java
@@ -1,0 +1,25 @@
+package com.trustamarket.apigateway.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+
+@Configuration
+@EnableWebFluxSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity http) {
+        http
+                .csrf(ServerHttpSecurity.CsrfSpec::disable)
+                .authorizeExchange(exchanges -> exchanges
+                        .pathMatchers("/actuator/**").permitAll() // 비인가 링크추가하시면됩니다.
+                        .anyExchange().authenticated())
+                .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()));
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/trustamarket/apigateway/config/SecurityConfig.java
+++ b/src/main/java/com/trustamarket/apigateway/config/SecurityConfig.java
@@ -2,10 +2,21 @@ package com.trustamarket.apigateway.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.Customizer;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+import org.springframework.security.oauth2.server.resource.authentication.ReactiveJwtAuthenticationConverterAdapter;
 import org.springframework.security.web.server.SecurityWebFilterChain;
+import reactor.core.publisher.Mono;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Configuration
 @EnableWebFluxSecurity
@@ -19,8 +30,41 @@ public class SecurityConfig {
                         .pathMatchers("/actuator/**").permitAll() // 비인가 링크추가하시면됩니다.
                         .pathMatchers("/api/v1/admin/**").hasRole("ADMIN") // ADMIN만 접근
                         .anyExchange().authenticated())
-                .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()));
+                .oauth2ResourceServer(
+                        oauth2 -> oauth2.jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter())));
 
         return http.build();
+    }
+
+    /**
+     * Keycloak JWT 토큰의 권한(roles) 정보를 Spring Security의 권한 체계(GrantedAuthority)로 변환하는
+     * 컨버터입니다.
+     * 기본적으로 Spring Security는 'scope' 클레임을 찾지만, Keycloak은 'realm_access.roles'에 역할을
+     * 저장하므로 별도 변환이 필요합니다.
+     */
+    @Bean
+    public Converter<Jwt, Mono<AbstractAuthenticationToken>> jwtAuthenticationConverter() {
+        JwtAuthenticationConverter jwtAuthenticationConverter = new JwtAuthenticationConverter();
+
+        // JWT에서 권한 정보를 추출하는 방식을 커스텀 설정
+        jwtAuthenticationConverter.setJwtGrantedAuthoritiesConverter(jwt -> {
+            // 1. Keycloak 토큰 내 'realm_access' 클레임 추출
+            Map<String, Object> realmAccess = jwt.getClaim("realm_access");
+            if (realmAccess == null || !realmAccess.containsKey("roles")) {
+                return Collections.emptyList();
+            }
+
+            // 2. 'roles' 리스트 추출
+            @SuppressWarnings("unchecked")
+            List<String> roles = (List<String>) realmAccess.get("roles");
+
+            // 3. 각 역할을 'ROLE_ADMIN'과 같은 Spring Security 표준 형식으로 변환
+            return roles.stream()
+                    .map(role -> new SimpleGrantedAuthority("ROLE_" + role.toUpperCase()))
+                    .collect(Collectors.toList());
+        });
+
+        // WebFlux 기반의 게이트웨이 환경에 맞게 어댑터로 감싸서 반환
+        return new ReactiveJwtAuthenticationConverterAdapter(jwtAuthenticationConverter);
     }
 }

--- a/src/main/java/com/trustamarket/apigateway/config/SecurityConfig.java
+++ b/src/main/java/com/trustamarket/apigateway/config/SecurityConfig.java
@@ -17,6 +17,7 @@ public class SecurityConfig {
                 .csrf(ServerHttpSecurity.CsrfSpec::disable)
                 .authorizeExchange(exchanges -> exchanges
                         .pathMatchers("/actuator/**").permitAll() // 비인가 링크추가하시면됩니다.
+                        .pathMatchers("/api/v1/admin/**").hasRole("ADMIN") // ADMIN만 접근
                         .anyExchange().authenticated())
                 .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()));
 

--- a/src/main/java/com/trustamarket/apigateway/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/trustamarket/apigateway/filter/JwtAuthenticationFilter.java
@@ -16,13 +16,34 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Component
 public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
 
+    private static final Set<String> ALLOWED_ROLES = Set.of("ADMIN", "INSPECTOR", "MEMBER");
+
     @Override
     public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+        // ① JWT 유무와 관계없이 X-User-* 헤더 항상 제거 (spoofing 방지)
+        ServerHttpRequest stripped = exchange.getRequest().mutate()
+                .headers(headers -> {
+                    headers.remove("Authorization");
+                    headers.remove("X-User-UUID");
+                    headers.remove("X-User-Email");
+                    headers.remove("X-User-Role");
+                    headers.remove("X-User-Name");
+                    headers.remove("X-User-Slack-Id");
+                    headers.remove("X-User-Enabled");
+                })
+                .build();
+
+        ServerWebExchange strippedExchange = exchange.mutate()
+                .request(stripped)
+                .build();
+
+        // ② 검증된 JWT에서 유저 정보를 추출하여 내부 라우팅용 헤더에 재주입 (MSA 내부 통신용)
         return ReactiveSecurityContextHolder.getContext()
                 .map(SecurityContext::getAuthentication)
                 .filter(Authentication::isAuthenticated)
@@ -30,20 +51,7 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
                 .filter(principal -> principal instanceof Jwt)
                 .cast(Jwt.class)
                 .map(jwt -> {
-                    ServerHttpRequest.Builder requestBuilder = exchange.getRequest().mutate();
-
-                    // ① 클라이언트가 보낸 X-User-* 헤더 전부 제거 (spoofing 방지)
-                    requestBuilder.headers(headers -> {
-                        headers.remove("Authorization");
-                        headers.remove("X-User-UUID");
-                        headers.remove("X-User-Email");
-                        headers.remove("X-User-Role");
-                        headers.remove("X-User-Name");
-                        headers.remove("X-User-Slack-Id");
-                        headers.remove("X-User-Enabled");
-                    });
-
-                    // ② 검증된 JWT에서 유저 정보를 추출하여 내부 라우팅용 헤더에 주입 (MSA 내부 통신용)
+                    ServerHttpRequest.Builder requestBuilder = strippedExchange.getRequest().mutate();
                     
                     // 1. 유저 고유 식별자(UUID) 주입
                     if (jwt.getSubject() != null) {
@@ -64,10 +72,9 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
                             @SuppressWarnings("unchecked")
                             List<String> roles = (List<String>) rolesObj;
                             String roleString = roles.stream()
-                                    .map(role -> {
-                                        String r = role.toUpperCase();
-                                        return r.startsWith("ROLE_") ? r : "ROLE_" + r;
-                                    })
+                                    .map(String::toUpperCase)
+                                    .filter(ALLOWED_ROLES::contains)
+                                    .map(r -> "ROLE_" + r)
                                     .collect(Collectors.joining(","));
                             if (!roleString.isEmpty()) {
                                 requestBuilder.header("X-User-Role", roleString);
@@ -94,9 +101,9 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
                         requestBuilder.header("X-User-Enabled", enabled.toString());
                     }
                     
-                    return exchange.mutate().request(requestBuilder.build()).build();
+                    return strippedExchange.mutate().request(requestBuilder.build()).build();
                 })
-                .defaultIfEmpty(exchange)
+                .defaultIfEmpty(strippedExchange)
                 .flatMap(chain::filter);
     }
 

--- a/src/main/java/com/trustamarket/apigateway/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/trustamarket/apigateway/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,107 @@
+package com.trustamarket.apigateway.filter;
+
+import org.springframework.cloud.gateway.filter.GatewayFilterChain;
+import org.springframework.cloud.gateway.filter.GlobalFilter;
+import org.springframework.core.Ordered;
+import org.springframework.http.server.reactive.ServerHttpRequest;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.ReactiveSecurityContextHolder;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.stereotype.Component;
+import org.springframework.web.server.ServerWebExchange;
+import reactor.core.publisher.Mono;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
+
+    @Override
+    public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
+        return ReactiveSecurityContextHolder.getContext()
+                .map(SecurityContext::getAuthentication)
+                .filter(Authentication::isAuthenticated)
+                .map(Authentication::getPrincipal)
+                .filter(principal -> principal instanceof Jwt)
+                .cast(Jwt.class)
+                .map(jwt -> {
+                    ServerHttpRequest.Builder requestBuilder = exchange.getRequest().mutate();
+
+                    // ① 클라이언트가 보낸 X-User-* 헤더 전부 제거 (spoofing 방지)
+                    requestBuilder.headers(headers -> {
+                        headers.remove("Authorization");
+                        headers.remove("X-User-UUID");
+                        headers.remove("X-User-Email");
+                        headers.remove("X-User-Role");
+                        headers.remove("X-User-Name");
+                        headers.remove("X-User-Slack-Id");
+                        headers.remove("X-User-Enabled");
+                    });
+
+                    // ② 검증된 JWT에서 유저 정보를 추출하여 내부 라우팅용 헤더에 주입 (MSA 내부 통신용)
+                    
+                    // 1. 유저 고유 식별자(UUID) 주입
+                    if (jwt.getSubject() != null) {
+                        requestBuilder.header("X-User-UUID", jwt.getSubject());
+                    }
+                    
+                    // 2. 유저 이메일 주입
+                    String email = jwt.getClaimAsString("email");
+                    if (email != null) {
+                        requestBuilder.header("X-User-Email", email);
+                    }
+                    
+                    // 3. 유저 권한(Role) 추출 및 Spring Security 규칙(ROLE_ 접두사)에 맞게 변환하여 주입
+                    Map<String, Object> realmAccess = jwt.getClaim("realm_access");
+                    if (realmAccess != null && realmAccess.containsKey("roles")) {
+                        Object rolesObj = realmAccess.get("roles");
+                        if (rolesObj instanceof List) {
+                            @SuppressWarnings("unchecked")
+                            List<String> roles = (List<String>) rolesObj;
+                            String roleString = roles.stream()
+                                    .map(role -> {
+                                        String r = role.toUpperCase();
+                                        return r.startsWith("ROLE_") ? r : "ROLE_" + r;
+                                    })
+                                    .collect(Collectors.joining(","));
+                            if (!roleString.isEmpty()) {
+                                requestBuilder.header("X-User-Role", roleString);
+                            }
+                        }
+                    }
+                    
+                    // 4. 유저 이름 주입 (한글 등 비-ASCII 문자 깨짐 방지를 위해 UTF-8 URL 인코딩 적용)
+                    String name = jwt.getClaimAsString("name");
+                    if (name != null) {
+                        String encodedName = URLEncoder.encode(name, StandardCharsets.UTF_8);
+                        requestBuilder.header("X-User-Name", encodedName);
+                    }
+                    
+                    // 5. 알림 및 연동을 위한 Slack ID 주입
+                    String slackId = jwt.getClaimAsString("slack_id");
+                    if (slackId != null) {
+                        requestBuilder.header("X-User-Slack-Id", slackId);
+                    }
+                    
+                    // 6. 계정 활성화 상태 주입
+                    Boolean enabled = jwt.getClaimAsBoolean("enabled");
+                    if (enabled != null) {
+                        requestBuilder.header("X-User-Enabled", enabled.toString());
+                    }
+                    
+                    return exchange.mutate().request(requestBuilder.build()).build();
+                })
+                .defaultIfEmpty(exchange)
+                .flatMap(chain::filter);
+    }
+
+    @Override
+    public int getOrder() {
+        return 0;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -10,15 +10,20 @@ spring:
       server:
         webflux:
           routes:
-            - id: inspection-service
+            - id: inspection-service-centers
               uri: lb://inspection-service
               predicates:
-                - Path=/api/inspections/**
+                - Path=/api/v1/centers/**
+
+            - id: inspection-service-inspections
+              uri: lb://inspection-service
+              predicates:
+                - Path=/api/v1/inspections/**
 
             - id: delivery-service
               uri: lb://delivery-service
               predicates:
-                - Path=/api/deliveries/**
+                - Path=/api/v1/deliveries/**
 
           default-filters:
             - AddResponseHeader=X-Gateway, trusta-market

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -8,7 +8,7 @@ spring:
     oauth2:
       resource-server:
         jwt:
-          issuer-uri: http://localhost:9090/realms/trusta
+          issuer-uri: ${KEYCLOAK_ISSUER_URI:http://localhost:9090/realms/trusta}
 
   cloud:
     gateway:
@@ -39,11 +39,6 @@ spring:
               uri: lb://user-service
               predicates:
                 - Path=/api/v1/admin/users/**, /api/v1/admin/reports/**, /api/v1/admin/accounts/**
-
-            - id: user-service-internal
-              uri: lb://user-service
-              predicates:
-                - Path=/internal/users/**
 
           default-filters:
             - AddResponseHeader=X-Gateway, trusta-market

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,11 @@ server:
 spring:
   application:
     name: api-gateway
+  security:
+    oauth2:
+      resource-server:
+        jwt:
+          issuer-uri: http://localhost:9090/realms/trusta
 
   cloud:
     gateway:
@@ -24,6 +29,21 @@ spring:
               uri: lb://delivery-service
               predicates:
                 - Path=/api/v1/deliveries/**
+
+            - id: user-service
+              uri: lb://user-service
+              predicates:
+                - Path=/api/v1/users/**, /api/v1/reports/**
+
+            - id: user-service-admin
+              uri: lb://user-service
+              predicates:
+                - Path=/api/v1/admin/users/**, /api/v1/admin/reports/**, /api/v1/admin/accounts/**
+
+            - id: user-service-internal
+              uri: lb://user-service
+              predicates:
+                - Path=/internal/users/**
 
           default-filters:
             - AddResponseHeader=X-Gateway, trusta-market


### PR DESCRIPTION
## 🌱 설명

JWT Gateway 에서 Keycloak 기반 JWT 서명 검증 및 X-USER-* 헤더 변환 필터 구현했습니다.
클라이언트의 JWT 를 Gateway 에서 한 번만 검증하고 , 각 서비스는 X-User-* 헤더만 신뢰하는 구조입니다

## 📌 관련 이슈

close #4 

## ✅ 주요 변경 사항

- JwtAuthentiactionFilter 구현  
  -  Keycloak 공개키로 JWT 서명 검증 후 claims 를 X-User-* 헤더로 변환하고 클라이언트가 보낸 기존 X-User-* 헤더는 제거합니다(spoofing) 방지
- SecurityConfig 구현 
  - 추가 설명 참조
- yml 파일에 keycloak 설정 추가했습니다
- - 포트는 9090 입니다 
- internal 라우트를 제거하는 방향으로 수정하였습니다
- Role 추출 시 filter를 추가하여 role 화이트 리스트 필터링을 적용시켯습니다.
- Admin / internal 경로 접근 제어 문제를 수정했습니다. (denyAll())
- JWT 없는 요청에도 X-User-* 헤더가 적용되던걸 수정했습니다

## 📝 체크리스트

> PR 올리기 전에 아래 항목을 확인해주세요.

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [x] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [x] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

> 인증 / 인가 흐름
클라이언트 - > Gateway (JWT 검증) - > X-User-* 헤더 변환 -> 각서비스 
토큰 없이 접근 가능한 public 엔드 포인트가 있으시면 SecurityConfig 에 추가하시면됩니다!

```
// SecurityConfig.java
@Bean
public SecurityWebFilterChain springSecurityFilterChain(ServerHttpSecurity http) {
    http
        .csrf(ServerHttpSecurity.CsrfSpec::disable)
        .authorizeExchange(exchanges -> exchanges
            .pathMatchers("/actuator/**").permitAll()
            .pathMatchers("/internal/**").denyAll()

            // 비인증 경로 추가는 여기바로아래에작성하셔야됩니다
            // 예시: 상품 목록 조회
            // .pathMatchers(HttpMethod.GET, "/api/v1/products/**").permitAll()

            .anyExchange().authenticated()
        )
        .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()));

    return http.build();
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OAuth2/OIDC JWT authentication for the gateway with role-based access (admin-restricted routes).
  * Propagates authenticated user info (id, email, name, role, slack id, enabled) to downstream services via request headers.
  * Keeps management/actuator endpoints publicly accessible.

* **Chores**
  * Reworked gateway routes to use versioned /api/v1/* paths and updated service routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->