### PR TITLE
[refactor] SecurityConfig 내에 JWT 권한정보 추출방식 컨버터 추가

### DIFF
--- a/src/main/java/com/trustamarket/apigateway/config/SecurityConfig.java
+++ b/src/main/java/com/trustamarket/apigateway/config/SecurityConfig.java
@@ -2,10 +2,21 @@ package com.trustamarket.apigateway.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.Customizer;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.security.authentication.AbstractAuthenticationToken;
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
 import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
+import org.springframework.security.oauth2.server.resource.authentication.ReactiveJwtAuthenticationConverterAdapter;
 import org.springframework.security.web.server.SecurityWebFilterChain;
+import reactor.core.publisher.Mono;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Configuration
 @EnableWebFluxSecurity
@@ -19,8 +30,41 @@ public class SecurityConfig {
                         .pathMatchers("/actuator/**").permitAll() // 비인가 링크추가하시면됩니다.
                         .pathMatchers("/api/v1/admin/**").hasRole("ADMIN") // ADMIN만 접근
                         .anyExchange().authenticated())
-                .oauth2ResourceServer(oauth2 -> oauth2.jwt(Customizer.withDefaults()));
+                .oauth2ResourceServer(
+                        oauth2 -> oauth2.jwt(jwt -> jwt.jwtAuthenticationConverter(jwtAuthenticationConverter())));
 
         return http.build();
+    }
+
+    /**
+     * Keycloak JWT 토큰의 권한(roles) 정보를 Spring Security의 권한 체계(GrantedAuthority)로 변환하는
+     * 컨버터입니다.
+     * 기본적으로 Spring Security는 'scope' 클레임을 찾지만, Keycloak은 'realm_access.roles'에 역할을
+     * 저장하므로 별도 변환이 필요합니다.
+     */
+    @Bean
+    public Converter<Jwt, Mono<AbstractAuthenticationToken>> jwtAuthenticationConverter() {
+        JwtAuthenticationConverter jwtAuthenticationConverter = new JwtAuthenticationConverter();
+
+        // JWT에서 권한 정보를 추출하는 방식을 커스텀 설정
+        jwtAuthenticationConverter.setJwtGrantedAuthoritiesConverter(jwt -> {
+            // 1. Keycloak 토큰 내 'realm_access' 클레임 추출
+            Map<String, Object> realmAccess = jwt.getClaim("realm_access");
+            if (realmAccess == null || !realmAccess.containsKey("roles")) {
+                return Collections.emptyList();
+            }
+
+            // 2. 'roles' 리스트 추출
+            @SuppressWarnings("unchecked")
+            List<String> roles = (List<String>) realmAccess.get("roles");
+
+            // 3. 각 역할을 'ROLE_ADMIN'과 같은 Spring Security 표준 형식으로 변환
+            return roles.stream()
+                    .map(role -> new SimpleGrantedAuthority("ROLE_" + role.toUpperCase()))
+                    .collect(Collectors.toList());
+        });
+
+        // WebFlux 기반의 게이트웨이 환경에 맞게 어댑터로 감싸서 반환
+        return new ReactiveJwtAuthenticationConverterAdapter(jwtAuthenticationConverter);
     }
 }


### PR DESCRIPTION
## 🌱 설명
SecurityConfig.java에 커스텀 컨버터 설정


## 📌 관련 이슈
#4 #5 

close #

## ✅ 주요 변경 사항

- Springsecurity는 기본적으로 payloade 에서 scope 또는 scp 라는 이름의 클레임을 찾는데 값들 앞에 SCOPE_ 라는 접두사를 붙여야 권한으로 인식하는 방식입니다
- 하지만 현재 구현된 상황으로는 springsecurity가 keycloak 의 role 을 읽지못해서 무조건 403 에러가 발생하는상황이였습니다
- 그래서 커스텀 컨버터를 등록해서 해결했습니다
- jwtAuthenticationConverter 빈 추가
 -  Keycloak JWT의 realm_access.roles 경로에서 권한 목록을 가져와 ROLE_ 접두사를 붙여 Spring Security가 이해할 수 있는 GrantedAuthority로 변환합니다.

## 📝 체크리스트

> PR 올리기 전에 아래 항목을 확인해주세요.

- [ ] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [ ] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [ ] 관련 이슈와 연결했나요?
- [ ] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [ ] 제가 작성한 코드를 스스로 리뷰했나요?
- [ ] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명
