### PR TITLE
[refactor] userservice 비인가링크 추가 + enabled true

### DIFF
--- a/src/main/java/com/trustamarket/apigateway/config/SecurityConfig.java
+++ b/src/main/java/com/trustamarket/apigateway/config/SecurityConfig.java
@@ -28,6 +28,7 @@ public class SecurityConfig {
                 .csrf(ServerHttpSecurity.CsrfSpec::disable)
                 .authorizeExchange(exchanges -> exchanges
                         .pathMatchers("/actuator/**").permitAll() // 비인가 링크추가하시면됩니다.
+                        .pathMatchers("/api/v1/users/signup").permitAll()
                         .pathMatchers("/api/v1/admin/**").hasRole("ADMIN") // ADMIN만 접근
                         .anyExchange().authenticated())
                 .oauth2ResourceServer(

--- a/src/main/java/com/trustamarket/apigateway/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/trustamarket/apigateway/filter/JwtAuthenticationFilter.java
@@ -97,7 +97,8 @@ public class JwtAuthenticationFilter implements GlobalFilter, Ordered {
                     
                     // 6. 계정 활성화 상태 주입
                     Boolean enabled = jwt.getClaimAsBoolean("enabled");
-                    if (enabled != null) {
+                    if (enabled == null) {
+                        enabled = true; //나중에 맞출 부분: 운영 환경(Keycloak 관리자 페이지)에서 Protocol Mappers 설정을 통해 JWT 토큰 자체에 "enabled": true 항목이 포함되도록 세팅
                         requestBuilder.header("X-User-Enabled", enabled.toString());
                     }
                     

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -40,6 +40,16 @@ spring:
               predicates:
                 - Path=/api/v1/admin/users/**, /api/v1/admin/reports/**, /api/v1/admin/accounts/**
 
+            - id: order-service
+              uri: lb://order-service
+              predicates:
+                - Path=/api/v1/orders/**
+
+            - id: order-service-admin
+              uri: lb://order-service
+              predicates:
+                - Path=/api/v1/admin/orders/**
+
           default-filters:
             - AddResponseHeader=X-Gateway, trusta-market
 


### PR DESCRIPTION
## 🌱 설명

user 회원가입 비인가링크 추가했습니다
계정 활성화 상태가 현재 X-User 를 true로 반환하도록 수정하엿습니다

## ✅ 주요 변경 사항

- SecurityConfig 비인가링크 user 추가
- JWTAuthentiactionFilter enabled 임시 true반환으로 수정
-

## 📝 체크리스트

> PR 올리기 전에 아래 항목을 확인해주세요.

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [ ] 관련 이슈와 연결했나요?
- [ ] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [ ] 제가 작성한 코드를 스스로 리뷰했나요?
- [ ] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명
enabled 같은경우 나중에 운영환경에서 keycloak 관리자 페이지에서 Protocoo Mappers 설정으로 
JWT 토큰에 enabled:true 항목을 넣도록 세팅할예정입니다


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Unauthenticated users can now access the signup endpoint without requiring prior authentication.

* **Bug Fixes**
  * Fixed handling of user enabled status in request processing—now defaults to enabled when not explicitly specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->