### PR TITLE
api-gateway product-service 라우트 추가

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -30,6 +30,11 @@ spring:
               predicates:
                 - Path=/api/v1/deliveries/**
 
+            - id: product-service
+              uri: lb://product-service
+              predicates:
+                - Path=/api/products/**, /api/categories/**
+
             - id: user-service
               uri: lb://user-service
               predicates:


### PR DESCRIPTION
gateway routes 에 product-service 자체가 빠져있어서 /api/products, /api/categories 가 404. 라우트 추가.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured gateway routing for product and category services, enabling access through `/api/products` and `/api/categories` endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->