### PR TITLE
chore: GKE 배포 설정 추가 (api-gateway)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,51 @@
+name: Build & Deploy api-gateway
+
+on:
+  push:
+    branches: [develop]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      IMAGE: asia-northeast3-docker.pkg.dev/trusta-market-id/trusta-registry-services/api-gateway
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Authenticate to GCP (WIF)
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: projects/37902116541/locations/global/workloadIdentityPools/trusta-pool-github/providers/trusta-provider-github
+          service_account: trusta-sa-github-deployer@trusta-market-id.iam.gserviceaccount.com
+
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker auth
+        run: gcloud auth configure-docker asia-northeast3-docker.pkg.dev --quiet
+
+      - name: Build Docker image
+        run: docker build -t $IMAGE:${{ github.sha }} -t $IMAGE:latest .
+
+      - name: Push image
+        run: docker push --all-tags $IMAGE
+
+      - name: Get GKE credentials
+        uses: google-github-actions/get-gke-credentials@v2
+        with:
+          cluster_name: trusta-cluster
+          location: asia-northeast3-a
+
+      - name: Apply Deployment (with image tag substitution)
+        run: sed "s|PLACEHOLDER|${{ github.sha }}|g" k8s/deployment.yaml | kubectl apply -f -
+
+      - name: Apply Service
+        run: kubectl apply -f k8s/service.yaml
+
+      - name: Wait for rollout
+        run: kubectl rollout status deployment/api-gateway --timeout=5m

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,33 @@
+# syntax=docker/dockerfile:1.7
+
+# ──────────────────────────────────────────────────────────────
+# Builder — Gradle 로 bootJar 생성
+# ──────────────────────────────────────────────────────────────
+FROM gradle:8.10-jdk21-alpine AS builder
+WORKDIR /workspace
+
+COPY settings.gradle build.gradle ./
+COPY gradle ./gradle
+RUN gradle dependencies --no-daemon
+
+COPY src ./src
+
+RUN gradle bootJar --no-daemon \
+ && cp build/libs/*.jar /workspace/app.jar
+
+# ──────────────────────────────────────────────────────────────
+# Runtime — JRE 만 포함한 경량 이미지
+# ──────────────────────────────────────────────────────────────
+FROM eclipse-temurin:21-jre-alpine
+WORKDIR /app
+
+# Non-root 실행 — UID 1000 (K8s securityContext.runAsUser 와 일치).
+RUN addgroup -g 1000 -S spring && adduser -u 1000 -S spring -G spring
+
+COPY --from=builder --chown=spring:spring /workspace/app.jar /app/app.jar
+
+USER spring:spring
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-XX:MaxRAMPercentage=75.0", "-jar", "/app/app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ ext {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    implementation 'io.micrometer:micrometer-registry-prometheus'
     implementation 'org.springframework.cloud:spring-cloud-starter-gateway-server-webflux'
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,57 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api-gateway
+  labels:
+    app: api-gateway
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: api-gateway
+  template:
+    metadata:
+      labels:
+        app: api-gateway
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      containers:
+        - name: api-gateway
+          image: asia-northeast3-docker.pkg.dev/trusta-market-id/trusta-registry-services/api-gateway:PLACEHOLDER
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+          ports:
+            - containerPort: 8080
+          env:
+            - name: SPRING_PROFILES_ACTIVE
+              value: "k8s"
+          resources:
+            requests:
+              cpu: 500m
+              memory: 1Gi
+            limits:
+              cpu: 1000m
+              memory: 2Gi
+          # startupProbe — gateway 시작 시 issuer-uri 의 JWKS 가져옴. Keycloak 응답 변동 고려.
+          startupProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            failureThreshold: 30
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: 8080
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: 8080
+            periodSeconds: 5

--- a/k8s/hpa.yaml
+++ b/k8s/hpa.yaml
@@ -1,0 +1,22 @@
+# Phase 1 미적용 — 매니페스트만 두고 kubectl apply 안 함.
+# Phase 2 부하 테스트 시 활성화 (PRD §8).
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: api-gateway
+  labels:
+    app: api-gateway
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: api-gateway
+  minReplicas: 1
+  maxReplicas: 5
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: 70

--- a/k8s/service.yaml
+++ b/k8s/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: api-gateway
+  labels:
+    app: api-gateway
+spec:
+  type: ClusterIP
+  selector:
+    app: api-gateway
+  ports:
+    - port: 80
+      targetPort: 8080
+      protocol: TCP

--- a/src/main/resources/application-k8s.yml
+++ b/src/main/resources/application-k8s.yml
@@ -1,0 +1,13 @@
+# K8s 환경 전용 override (SPRING_PROFILES_ACTIVE=k8s 일 때만 로드).
+# 로컬 application.yml 의 localhost 기반 값들을 K8s Service DNS 로 갈음.
+eureka:
+  client:
+    service-url:
+      defaultZone: http://eureka-server/eureka/
+
+spring:
+  security:
+    oauth2:
+      resource-server:
+        jwt:
+          issuer-uri: http://keycloak/realms/trusta

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -93,10 +93,13 @@ eureka:
     prefer-ip-address: true
 
 management:
+  endpoint:
+    health:
+      probes:
+        enabled: true
+    gateway:
+      access: unrestricted
   endpoints:
     web:
       exposure:
-        include: health, info, gateway
-  endpoint:
-    gateway:
-      access: unrestricted
+        include: health, info, gateway, prometheus


### PR DESCRIPTION
## 🌱 설명

api-gateway 컨테이너화 + GKE 자동 배포 셋업. Spring Cloud Gateway (WebFlux).
K8s 환경 override 는 `application-k8s.yml` 로 분리 — Eureka 와 Keycloak issuer 를 K8s Service DNS 로.

## 📌 관련 이슈

해당 없음 (인프라 셋업, 이슈 생략)

## ✅ 주요 변경 사항

- `application.yml` — `management` 블록 보강 (health probes 활성, exposure 에 `prometheus` 추가). 기존 routes/Eureka/JWT 설정 유지
- `application-k8s.yml` (신규) — Spring Profile `k8s`:
  - `eureka.client.service-url.defaultZone: http://eureka-server/eureka/`
  - `spring.security.oauth2.resource-server.jwt.issuer-uri: http://keycloak/realms/trusta`
- `build.gradle` — `micrometer-registry-prometheus` 의존성 추가
- `Dockerfile` — multi-stage, non-root spring user (UID 1000), `MaxRAMPercentage=75`, `EXPOSE 8080`
- `k8s/deployment.yaml` — `replicas: 1` (Phase 1), securityContext, startupProbe 5s × 30 = 150s (gateway 가 issuer-uri 의 JWKS 가져오는 시간 고려), liveness/readiness 분리
- `k8s/service.yaml` — ClusterIP `port 80 → targetPort 8080`. 외부 노출은 후속 Ingress 단계 (PRD §9-#11)
- `k8s/hpa.yaml` — 작성만, **Phase 1 에선 apply 안 함**. Phase 2 부하 테스트 때 활성화 (minReplicas 1 / maxReplicas 5 / CPU 70%)
- `.github/workflows/deploy.yml` — develop push + workflow_dispatch, WIF → AR → GKE 흐름

## 📝 체크리스트

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [ ] 관련 이슈와 연결했나요? *(인프라 셋업이라 이슈 생략)*
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [x] 기존 테스트와 충돌하지 않음을 확인했나요? (`./gradlew compileJava` BUILD SUCCESSFUL)

## 🧪 검증 절차

```bash
kubectl get pods -l app=api-gateway -o wide          # 1/1 Running
kubectl logs deployment/api-gateway --tail=100        # Eureka 등록 + Keycloak JWKS 로드 메시지
kubectl port-forward svc/eureka-server 8761:80        # Eureka 대시보드에서 api-gateway 등록 확인
kubectl port-forward svc/api-gateway 8080:80          # /actuator/health, /actuator/gateway/routes 응답 확인
```

도메인 서비스 (user/order/...) 아직 배포 전이라 라우팅 호출은 503/404 정상.

## 📚 추가 설명 / 후속

- **Phase 1 컨텍스트**: replicas 1, HPA 미적용 — 의도된 한계 도달 시나리오 부하 테스트 위해 (PRD §8)
- **외부 노출은 후속 PR**: Static External IP + Cloud DNS (`api.trusta-market.site`) + Ingress + ManagedCertificate (Google-managed SSL). 현재 ClusterIP 라 cluster 내부에서만 접근 (PRD §9-#11)
- **JWT issuer-uri**: K8s Service DNS (`http://keycloak/realms/trusta`) 사용. 운영 진입 시 외부 도메인 (`https://auth.trusta-market.site/realms/trusta`) 으로 변경 (Keycloak 도 Ingress 노출 후)
- **HPA 적용 시점**: Phase 2 부하 테스트에서 활성화 (`kubectl apply -f k8s/hpa.yaml`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automated deployment pipeline to Kubernetes with comprehensive health checks and readiness probes.
  * Horizontal auto-scaling that dynamically adjusts capacity based on CPU utilization (1–5 replicas).
  * Prometheus metrics integration for enhanced system monitoring and observability.

* **Chores**
  * Configured containerization and Kubernetes environment setup with security best practices.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trusta-market/api-gateway/pull/11)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->