### PR TITLE
feat: /api/v1/alerts/** route + permitAll (Cloud Monitoring webhook)

### DIFF
--- a/src/main/java/com/trustamarket/apigateway/config/SecurityConfig.java
+++ b/src/main/java/com/trustamarket/apigateway/config/SecurityConfig.java
@@ -30,6 +30,7 @@ public class SecurityConfig {
                         .pathMatchers("/actuator/**").permitAll() // 비인가 링크추가하시면됩니다.
                         .pathMatchers("/api/v1/users/signup").permitAll()
                         .pathMatchers("/demo/v1/payments/**").permitAll()
+                        .pathMatchers("/api/v1/alerts/**").permitAll()
                         .pathMatchers("/api/v1/admin/inspections/**").hasAnyRole("ADMIN", "INSPECTOR")
                         .pathMatchers("/api/v1/admin/**").hasRole("ADMIN")
                         .anyExchange().authenticated())

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -75,6 +75,11 @@ spring:
               predicates:
                 - Path=/demo/v1/payments/**
 
+            - id: notification-service-alerts
+              uri: lb://notification-service
+              predicates:
+                - Path=/api/v1/alerts/**
+
 
           default-filters:
             - AddResponseHeader=X-Gateway, trusta-market


### PR DESCRIPTION
## 🌱 설명

notification-service 의 Cloud Monitoring webhook endpoint (`POST /api/v1/alerts/cloud-monitoring`) 가 외부 (GCP) 에서 도달 가능하도록 gateway route + 인증 면제 추가.

## 📌 관련 이슈

-

## ✅ 주요 변경 사항

- `application.yml` 에 `notification-service-alerts` route 추가 (`/api/v1/alerts/**` → `lb://notification-service`)
- `SecurityConfig.java` 에 `/api/v1/alerts/**` permitAll 추가

## 📚 추가 설명

- Google Cloud Monitoring 의 webhook 호출은 JWT 못 보냄 → permitAll 필수
- 외부 노출 위험: gateway/keycloak 외 서비스 ClusterIP. `/api/v1/alerts/**` 는 알려진 endpoint 라 fake 호출 시 Discord spam 만 발생. 운영 진입 시 shared secret 헤더 검증 강화 예정
- 같이 가는 PR: notification-service#5