### PR TITLE
fix(gateway): probe timeout/failureThreshold 늘려 부하 시 restart 방지

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -46,19 +46,26 @@ spec:
               cpu: 1000m
               memory: 2500Mi
           # startupProbe — gateway 시작 시 issuer-uri 의 JWKS 가져옴. Keycloak 응답 변동 고려.
+          # timeoutSeconds default 1초 → 부하 시 응답 1초 안 못 함 → fail → restart cycle. 3 으로 늘림.
           startupProbe:
             httpGet:
               path: /actuator/health
               port: 8080
             failureThreshold: 30
             periodSeconds: 5
+            timeoutSeconds: 3
+          # 부하 중 한 번 응답 늦었다고 죽이지 않게 failureThreshold 늘림 (default 3 → 5).
           livenessProbe:
             httpGet:
               path: /actuator/health/liveness
               port: 8080
             periodSeconds: 10
+            timeoutSeconds: 3
+            failureThreshold: 5
           readinessProbe:
             httpGet:
               path: /actuator/health/readiness
               port: 8080
             periodSeconds: 5
+            timeoutSeconds: 3
+            failureThreshold: 5


### PR DESCRIPTION
## 🌱 설명

부하 테스트 (2000 RPS) 중 gateway pod `Exit 143 (SIGTERM)` + restart 2번 발생. 원인:

- `timeoutSeconds` default = **1초** → 부하 시 `/actuator/health` 응답 1초 안에 못 함 → probe fail
- liveness/readiness `failureThreshold` = **3** → 3번 연속 fail 즉시 restart (너무 엄격)

→ 부하 살짝 받자마자 죽음 → 옛 connection 다 끊김 → cascade

## ✅ 주요 변경 사항

- startup/liveness/readiness probe 의 `timeoutSeconds: 3` 추가 (default 1)
- liveness/readiness 의 `failureThreshold: 5` (default 3)

## 📝 체크리스트

- [x] develop 브랜치 기준으로 feature 브랜치를 생성했나요?
- [x] 코드 컨벤션 및 스타일 가이드를 준수했나요?
- [ ] 관련 이슈와 연결했나요?
- [x] 어려운 부분 / 공유가 필요한 부분에 주석을 추가했나요?
- [x] 제가 작성한 코드를 스스로 리뷰했나요?
- [ ] 기존 테스트와 충돌하지 않음을 확인했나요?

## 📚 추가 설명

추가 권장 (이 PR 외):
- HPA apply (`kubectl apply -f k8s/hpa.yaml`) — replicas 1 → 5 자동 scale. 현재 HPA manifest 만 있고 cluster 에 적용 X.
- 부하 테스트 재실행 시 위 변경으로 gateway 가 더 견디는지 측정.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated health check configurations to improve service reliability and stability during deployment operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trusta-market/api-gateway/pull/15?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->